### PR TITLE
Update docs/example/rewrite (sudden stickyingress)

### DIFF
--- a/docs/examples/rewrite/README.md
+++ b/docs/examples/rewrite/README.md
@@ -94,6 +94,6 @@ Server: nginx/1.11.10
 Date: Mon, 13 Mar 2017 14:57:15 GMT
 Content-Type: text/html
 Content-Length: 162
-Location: http://stickyingress.example.com/app1
+Location: http://approot.bar.com/app1
 Connection: keep-alive
 ```


### PR DESCRIPTION
App root example in rewrite README.md demonstrating effect of `nginx.ingress.kubernetes.io/app-root: /app1` mentioned some `stickyingress.example.com` from [affinity/cookie example](https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/affinity/cookie) when it should be `approot.bar.com`.

## What this PR does / why we need it:
Fix a slightly confusing example in documentation

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only